### PR TITLE
Update README with arXiv link and fix step numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ CLARE is an 84-million-parameter neural network that uses a classification-based
 *   Demonstrates an accuracy of 21.39% on a  solar storm test set.
 
 **Paper:** For a detailed description of the model architecture, dataset, and results, please refer to our paper:
-[CLARE: Classification-based Regression for Electron Temperature Prediction (arXiv link)](https://docs.google.com/document/d/17t7eBduGdQoqOX6EXzHKLkKA3nxHLFlVrFWtiy-d-cA/edit?usp=sharing)
+[CLARE: Classification-based Regression for Electron Temperature Prediction](https://arxiv.org/abs/2603.12470)
 
 ---
 
@@ -63,7 +63,7 @@ Follow these steps to set up the project environment:
     git lfs pull
     ```
 
-3.  **Install Dependencies:**
+2.  **Install Dependencies:**
     Install all the required Python packages using pip and the `requirements.txt` file:
     ```bash
     pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- Replace Google Doc placeholder link with published arXiv paper link (https://arxiv.org/abs/2603.12470)
- Fix installation step numbering (was skipping from 1 to 3)

## Test plan
- [ ] Verify arXiv link resolves correctly
- [ ] Confirm README renders properly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)